### PR TITLE
Implement csi templating on select attributes

### DIFF
--- a/pkg/apis/templating/templating.go
+++ b/pkg/apis/templating/templating.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templating
+
+import (
+	"bytes"
+	"text/template"
+
+	csiapi "github.com/jetstack/cert-manager-csi/pkg/apis/v1alpha1"
+)
+
+func RenderAttributeTemplates(attr map[string]string) (map[string]string, error) {
+	var err error
+
+	tmpls := &template.Template{}
+	if err = addAndParseTemplate(tmpls, csiapi.CommonNameKey); err != nil {
+		return nil, err
+	}
+	if err = addAndParseTemplate(tmpls, csiapi.DNSNamesKey); err != nil {
+		return nil, err
+	}
+	if err = addAndParseTemplate(tmpls, csiapi.URISANsKey); err != nil {
+		return nil, err
+	}
+
+	tmplData := csiapi.TemplatingData{
+		PodName:      attr[csiapi.CSIPodNameKey],
+		PodNamespace: attr[csiapi.CSIPodNamespaceKey],
+		PodUID:       attr[csiapi.CSIPodUIDKey],
+	}
+
+	for _, t := range tmpls.Templates() {
+		buf := new(bytes.Buffer)
+		if err := t.Execute(buf, tmplData); err != nil {
+			return nil, err
+		}
+		attr[t.Name()] = buf.String()
+	}
+
+	return attr, nil
+}
+
+func addAndParseTemplate(t *template.Template, k string) error {
+	if _, err := t.New(k).Parse(k); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/apis/v1alpha1/types.go
+++ b/pkg/apis/v1alpha1/types.go
@@ -61,3 +61,9 @@ type MetaData struct {
 
 	Attributes map[string]string `json:"attributes"`
 }
+
+type TemplatingData struct {
+	PodName      string
+	PodNamespace string
+	PodUID       string
+}

--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/jetstack/cert-manager-csi/pkg/apis/defaults"
+	"github.com/jetstack/cert-manager-csi/pkg/apis/templating"
 	csiapi "github.com/jetstack/cert-manager-csi/pkg/apis/v1alpha1"
 	"github.com/jetstack/cert-manager-csi/pkg/apis/validation"
 	"github.com/jetstack/cert-manager-csi/pkg/certmanager"
@@ -81,7 +82,12 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	attr, err := defaults.SetDefaultAttributes(attr)
+	attr, err := templating.RenderAttributeTemplates(attr)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	attr, err = defaults.SetDefaultAttributes(attr)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/test/e2e/suite/cases/template.go
+++ b/test/e2e/suite/cases/template.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cases
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	csi "github.com/jetstack/cert-manager-csi/pkg/apis"
+	"github.com/jetstack/cert-manager-csi/pkg/util"
+	"github.com/jetstack/cert-manager-csi/test/e2e/framework"
+)
+
+var _ = framework.CasesDescribe("Should template all templatable attributes correctly", func() {
+	f := framework.NewDefaultFramework("attr-templating")
+
+	It("should create a pod with a fully templated certificate request", func() {
+		testVolume := corev1.Volume{
+			Name: "tls",
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver: csi.GroupName,
+					VolumeAttributes: map[string]string{
+						"csi.cert-manager.io/issuer-name":  f.Issuer.Name,
+						"csi.cert-manager.io/issuer-kind":  f.Issuer.Kind,
+						"csi.cert-manager.io/issuer-group": f.Issuer.Group,
+						"csi.cert-manager.io/dns-names":    "a.example.com,b.example.com,{{ .PodName }}.my-service.{{ .PodNamespace }}",
+						"csi.cert-manager.io/uri-sans":     "spiffe://my-service.sandbox.cluster.local,http://{{ .PodName }}.my-service.{{ .PodNamespace }}",
+						"csi.cert-manager.io/ip-sans":      "192.168.0.1,123.4.5.6",
+						"csi.cert-manager.io/duration":     "123h",
+						"csi.cert-manager.io/is-ca":        "true",
+						"csi.cert-manager.io/common-name":  "{{ .PodName }}.my-service.{{ .PodNamespace }}",
+					},
+				},
+			},
+		}
+
+		renderedAttributes := map[string]string{
+			"csi.cert-manager.io/issuer-name":  f.Issuer.Name,
+			"csi.cert-manager.io/issuer-kind":  f.Issuer.Kind,
+			"csi.cert-manager.io/issuer-group": f.Issuer.Group,
+			"csi.cert-manager.io/dns-names":    "a.example.com,b.example.com,test-container-1.my-service." + f.Namespace.Name,
+			"csi.cert-manager.io/uri-sans":     "spiffe://my-service.sandbox.cluster.local,http://test-container-1.my-service." + f.Namespace.Name,
+			"csi.cert-manager.io/ip-sans":      "192.168.0.1,123.4.5.6",
+			"csi.cert-manager.io/duration":     "123h",
+			"csi.cert-manager.io/is-ca":        "true",
+			"csi.cert-manager.io/common-name":  "test-container-1.my-service." + f.Namespace.Name,
+		}
+
+		testPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: f.BaseName + "-",
+				Namespace:    f.Namespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					corev1.Container{
+						Name:    "test-container-1",
+						Image:   "busybox",
+						Command: []string{"sleep", "10000"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/tls",
+								Name:      "tls",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					testVolume,
+				},
+			},
+		}
+
+		By("Creating a Pod")
+		testPod, err := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).Create(testPod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Pod to become ready")
+		err = f.Helper().WaitForPodReady(f.Namespace.Name, testPod.Name, time.Second*10)
+		Expect(err).NotTo(HaveOccurred())
+
+		testPod, err = f.KubeClientSet.CoreV1().Pods(f.Namespace.Name).Get(testPod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensure the corresponding CertificateRequest should exist with the correct spec")
+		crName := util.BuildVolumeID(string(testPod.GetUID()), "tls")
+		cr, err := f.Helper().WaitForCertificateRequestReady(f.Namespace.Name, crName, time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = util.CertificateRequestMatchesSpec(cr, renderedAttributes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
```release-note
Added attribute templating for `csi.cert-manager.io/common-name`, `csi.cert-manager.io/dns-names` and `csi.cert-manager.io/uri-sans` via go templates.
The available pod values are:
- `PodName`
- `PodNamespace`
- `PodUID`

Docs: https://cert-manager.io/docs/usage/csi/#templating
```

closes #20

Contrary to suggestion in #20, I figured plain golang templating would be more friction-_less_ / less friction-_full_.

Docs are ready: https://github.com/cert-manager/website/pull/271